### PR TITLE
Update read_fs_transform.R

### DIFF
--- a/R/read_fs_transform.R
+++ b/R/read_fs_transform.R
@@ -262,6 +262,9 @@ parse.transform.matrix.lines <- function(file_lines, ignore_line_suffix=";") {
 
   line_idx = 1L;
   for(file_line in file_lines) {
+    
+    file_line <- trimws(file_line)
+    
     if(endsWith(file_line, ignore_line_suffix)) {
       file_line = substring(file_line, 1L, (nchar(file_line) - nchar(ignore_line_suffix)));
     }

--- a/R/read_fs_transform.R
+++ b/R/read_fs_transform.R
@@ -265,7 +265,7 @@ parse.transform.matrix.lines <- function(file_lines, ignore_line_suffix=";") {
     if(endsWith(file_line, ignore_line_suffix)) {
       file_line = substring(file_line, 1L, (nchar(file_line) - nchar(ignore_line_suffix)));
     }
-    matrix_row = as.double(strsplit(file_line, " ")[[1]]);
+    matrix_row = as.double(strsplit(trimws(file_line), " ")[[1]]);
     tm[line_idx, ] = matrix_row;
     line_idx = line_idx + 1L;
   }


### PR DESCRIPTION
* Added `trimws` to remove whitespace around xfm matrix

`freesurferformats:::parse.transform.matrix.lines` cannot parse Freesurfer template `cvs_avg35` `xfm` that looks like this:

```
MNI Transform File
% tkregister2

Transform_Type = Linear;
Linear_Transform =
   1.16106951   -0.00704342   -0.11204901    3.67494893 
  -0.01564112    1.14419806    0.09429374   -4.98407936 
   0.14128765   -0.18154892    1.24108684   10.31033230 ;
```

There are white spaces around matrix lines, which need to be removed before splitting