### PR TITLE
Make sure `faces` are integers before writing surface geometries

### DIFF
--- a/R/write_fs_surface.R
+++ b/R/write_fs_surface.R
@@ -35,6 +35,9 @@ write.fs.surface <- function(filepath, vertex_coords, faces, format='auto') {
     stop("Format must be one of c('auto', 'bin', 'asc', 'vtk', 'obj', 'off', 'ply', 'gii', 'mz3', 'byu').");
   }
 
+  if(!identical(storage.mode(faces), "integer")) {
+    storage.mode(faces) <- "integer"
+  }
   check.verts.faces(vertex_coords, faces);
 
   if(format == 'asc' | (format == 'auto' & filepath.ends.with(filepath, c('.asc')))) {
@@ -562,6 +565,9 @@ ply.header.lines <- function(num_verts, num_faces, use_vertex_colors) {
 #'
 #' @export
 write.fs.surface.gii <- function(filepath, vertex_coords, faces) {
+  if(!identical(storage.mode(faces), "integer")) {
+    storage.mode(faces) <- "integer"
+  }
   check.verts.faces(vertex_coords, faces);
   my_data_sets = list(vertex_coords, faces - 1L);
   xmltree = gifti_xml(my_data_sets, datatype=c('NIFTI_TYPE_FLOAT32', 'NIFTI_TYPE_INT32'), intent=c('NIFTI_INTENT_POINTSET', 'NIFTI_INTENT_TRIANGLE'));
@@ -599,6 +605,9 @@ write.fs.surface.gii <- function(filepath, vertex_coords, faces) {
 #' @export
 write.fs.surface.mz3 <- function(filepath, vertex_coords, faces, gzipped=TRUE) {
 
+  if(!identical(storage.mode(faces), "integer")) {
+    storage.mode(faces) <- "integer"
+  }
   check.verts.faces(vertex_coords, faces);
 
   faces = faces - 1L;


### PR DESCRIPTION
The goal is to fix this issue when writing double as integer32:

``` r
mesh <- rgl::icosahedron3d(diag(c(50, 50, 50, 1)))
f <- tempfile()

faces <- t(mesh$it)
faces
#>       [,1] [,2] [,3]
#>  [1,]    1    3    9
#>  [2,]    1    9    5
#>  [3,]    1    5    7
#>  [4,]    1    7   10
#>  [5,]    1   10    3
#>  [6,]    4   12    2
#>  [7,]    4    2   11
#>  [8,]    4   11    6
#>  [9,]    4    6    8
#> [10,]    4    8   12
#> [11,]    9    3    6
#> [12,]    5    9   11
#> [13,]    7    5    2
#> [14,]   10    7   12
#> [15,]    3   10    8
#> [16,]    2   12    7
#> [17,]   11    2    5
#> [18,]    6   11    9
#> [19,]    8    6    3
#> [20,]   12    8   10
# storage.mode(faces) <- "integer"
freesurferformats::write.fs.surface.gii(
  filepath = f,
  vertex_coords = t(mesh$vb[1:3, ]),
  faces = faces
)

m <- freesurferformats::read.fs.surface.gii(f)

m$faces
#>             [,1]       [,2]       [,3]
#>  [1,]          1 1073741825 1090519041
#>  [2,]          1 1090519041 1082130433
#>  [3,]          1 1082130433 1086324737
#>  [4,]          1 1086324737 1091567617
#>  [5,]          1 1091567617 1073741825
#>  [6,] 1077936129 1093664769 1065353217
#>  [7,] 1077936129 1065353217 1092616193
#>  [8,] 1077936129 1092616193 1084227585
#>  [9,] 1077936129 1084227585 1088421889
#> [10,] 1077936129 1088421889 1093664769
#> [11,] 1090519041 1073741825 1084227585
#> [12,] 1082130433 1090519041 1092616193
#> [13,] 1086324737 1082130433 1065353217
#> [14,] 1091567617 1086324737 1093664769
#> [15,] 1073741825 1091567617 1088421889
#> [16,] 1065353217 1093664769 1086324737
#> [17,] 1092616193 1065353217 1082130433
#> [18,] 1084227585 1092616193 1090519041
#> [19,] 1088421889 1084227585 1073741825
#> [20,] 1093664769 1088421889 1091567617
```
